### PR TITLE
Make optional classes pointers so that omitempty can take effect.

### DIFF
--- a/targets/go/make.js
+++ b/targets/go/make.js
@@ -149,6 +149,8 @@ function getModelPropertyDef(property, datatype) {
         return capitalizeFirstLetter(property.name) + " []" + basicType + " `json:\""+property.name+",omitempty\"`";
     else if (property.collection && property.collection === "map")
         return capitalizeFirstLetter(property.name) + " map[string]" + basicType + " `json:\""+property.name+",omitempty\"`";
+    else if (property.isclass && property.optional)
+        return capitalizeFirstLetter(property.name) + " *" + getPropertyGoType(property, datatype) + " `json:\"" + property.name + ",omitempty\"`";
     else if (property.collection)
         throw "Unknown collection type: " + property.collection + " for " + property.name + " in " + datatype.name;
 


### PR DESCRIPTION
Without this change optional classes often serialise to '{}' and can't take advantage of the 'omitempty' option to prevent serialisation. This is required for some requests that only allow a single member to be specified.