### PR TITLE
Include all PlayFab response fields in the custom error

### DIFF
--- a/targets/go/source/PlayFabHttp.go.ejs
+++ b/targets/go/source/PlayFabHttp.go.ejs
@@ -15,6 +15,7 @@ import (
 	"time"
 )
 
+// PlayFabResponse contains all fields returned from a PlayFab request
 type PlayFabResponse struct {
 	Code         int                    `json:"code"`
 	Status       string                 `json:"status"`
@@ -27,9 +28,9 @@ type PlayFabResponse struct {
 
 // CustomError contains data about an error during HTTP operation
 type CustomError struct {
-	msg      string
-	Code     ErrorCode
-	Response PlayFabResponse
+	msg       string
+	Code      ErrorCode
+	Response *PlayFabResponse
 }
 
 func (p *CustomError) Error() string { return p.msg }
@@ -40,7 +41,7 @@ func NewCustomError(msg string, code ErrorCode) *CustomError {
 }
 
 // NewCustomErrorWithResponse returns a new CustomError with a message, error code, and PlayFab response
-func NewCustomErrorWithResponse(msg string, code ErrorCode, response PlayFabResponse) *CustomError {
+func NewCustomErrorWithResponse(msg string, code ErrorCode, response *PlayFabResponse) *CustomError {
 	return &CustomError{msg: msg, Code: code, Response: response}
 }
 
@@ -203,7 +204,7 @@ func Request(p *Settings, b []byte, apiPath string, authKey string, authValue st
 		if result.Status != "" {
 			errorString = fmt.Sprintf("%s and status %s", errorString, result.Status)
 		}
-		return nil, NewCustomErrorWithResponse(errorString, ErrorDoRequest, result)
+		return nil, NewCustomErrorWithResponse(errorString, ErrorDoRequest, &result)
 	}
 
 	return result.Data, nil

--- a/targets/go/source/PlayFabHttp.go.ejs
+++ b/targets/go/source/PlayFabHttp.go.ejs
@@ -15,16 +15,21 @@ import (
 	"time"
 )
 
-type playFabResponse struct {
-	Code   int                    `json:"code"`
-	Status string                 `json:"status"`
-	Data   map[string]interface{} `json:"data"`
+type PlayFabResponse struct {
+	Code         int                    `json:"code"`
+	Status       string                 `json:"status"`
+	Data         map[string]interface{} `json:"data"`
+	Error        string                 `json:"error"`
+	ErrorCode    int                    `json:"errorCode"`
+	ErrorMessage string                 `json:"errorMessage"`
+	ErrorDetails map[string][]string    `json:"errorDetails"`
 }
 
 // CustomError contains data about an error during HTTP operation
 type CustomError struct {
-	msg  string
-	Code ErrorCode
+	msg      string
+	Code     ErrorCode
+	Response PlayFabResponse
 }
 
 func (p *CustomError) Error() string { return p.msg }
@@ -32,6 +37,11 @@ func (p *CustomError) Error() string { return p.msg }
 // NewCustomError returns a new CustomError with a message and an error code
 func NewCustomError(msg string, code ErrorCode) *CustomError {
 	return &CustomError{msg: msg, Code: code}
+}
+
+// NewCustomErrorWithResponse returns a new CustomError with a message, error code, and PlayFab response
+func NewCustomErrorWithResponse(msg string, code ErrorCode, response PlayFabResponse) *CustomError {
+	return &CustomError{msg: msg, Code: code, Response: response}
 }
 
 // ErrorCode is a custom error code
@@ -182,7 +192,7 @@ func Request(p *Settings, b []byte, apiPath string, authKey string, authValue st
 		return nil, NewCustomError(err.Error(), ErrorDoRequest)
 	}
 
-	result := playFabResponse{}
+	result := PlayFabResponse{}
 	err = json.Unmarshal(bodyBytes, &result)
 	if err != nil {
 		return nil, NewCustomError(err.Error(), ErrorUnmarshal)
@@ -193,7 +203,7 @@ func Request(p *Settings, b []byte, apiPath string, authKey string, authValue st
 		if result.Status != "" {
 			errorString = fmt.Sprintf("%s and status %s", errorString, result.Status)
 		}
-		return nil, NewCustomError(errorString, ErrorDoRequest)
+		return nil, NewCustomErrorWithResponse(errorString, ErrorDoRequest, result)
 	}
 
 	return result.Data, nil


### PR DESCRIPTION
Without this change important information regarding the nature of the error is lost such as the error details.